### PR TITLE
Stripping callables from args when creating cache path

### DIFF
--- a/src/intervention-wrapper.php
+++ b/src/intervention-wrapper.php
@@ -17,7 +17,7 @@ class Intervention_Wrapper {
 
 
 	function __construct( $src=null, $intervention_args=array(), $options=array() ) {
-		
+
 		if ( empty( $src ) ) {
 			return new WP_Error( 'No image source provided' );
 		}
@@ -28,7 +28,7 @@ class Intervention_Wrapper {
 		// Intervention args
 		// image.intervention.io
 		$this->intervention_args 	= $intervention_args;
-		
+
 		// Allow defaults to be overriden on a global basis
 		$default_options = apply_filters('wpi_default_options', array(
 			'quality'		=> 80,
@@ -49,26 +49,26 @@ class Intervention_Wrapper {
 
 
 
-	
+
 
 	public function process() {
 
-		// Init Intervention Library	
+		// Init Intervention Library
 		$this->intervention_instance = Image::make( $this->src );
 
-		// Cache the setting of the cache path 
+		// Cache the setting of the cache path
 		$this->set_cache_file_path();
 
 		// If we have a cache of this image then just return that directly
 		if ( $this->options['cache'] && $this->check_cache() ) {
-			//dump("FROM CACHE");	
+			//dump("FROM CACHE");
 			return $this->get_cache_file_path( 'uri' ); // return a URI not a DIR
-		}	
-		
+		}
+
 		//dump("NOT FROM CACHE");
 
 		// Proxy all args to underlying Intevention library
-		// note: args will be called in order defined in the 
+		// note: args will be called in order defined in the
 		// $intervention_args array
 		foreach ($this->intervention_args as $sFn => $aFnArgs)
 		{
@@ -82,34 +82,34 @@ class Intervention_Wrapper {
 
 		// Save resulting file to cache dir
 		$this->save_image();
-		
+
 		// Return a public URL to the image
 		return $this->get_cache_file_path( 'uri' );
-	
+
 	}
 
 
-	private function check_cache() {	
+	private function check_cache() {
 		$cache_file_path = $this->get_cache_file_path();
 
 		if ( file_exists( $cache_file_path ) ) {
 			// Update the timestamp on the file to show it's been accessed
-			touch( $cache_file_path );		
+			touch( $cache_file_path );
 			return $cache_file_path;
 		}
 	}
 
 	private function get_cache_file_path( $type='directory' ) {
 
-		$cache_file_path;		
+		$cache_file_path;
 
 		if ( empty( $this->cache_file_path ) ) {
 			$this->set_cache_file_path();
 
-		} 
+		}
 
 		$cache_file_path = $this->cache_file_path;
-		
+
 		// TODO: account for situations where user has filtered the cache path
 		// we can't reply on str_replace or upload dir...
 		if ( $type === 'uri' ) {
@@ -121,7 +121,7 @@ class Intervention_Wrapper {
 	}
 
 	private function set_cache_file_path() {
-		$args = $this->intervention_args;
+		$args = $this->strip_callables($this->intervention_args);
 
 		// Sort the array by key to ensure consistency of caching filename
 		ksort($args);
@@ -147,7 +147,7 @@ class Intervention_Wrapper {
 		return "." . str_replace('image/', '', $mime);
 	}
 
-	
+
 	/**
 	 * RECURSIVE IMPLODE
 	 * @param  array $pieces the array to implode
@@ -155,7 +155,7 @@ class Intervention_Wrapper {
 	 * @return string         the imploded array
 	 */
 	private function r_implode( $pieces, $glue ) {
-		
+
 	  	$retVal = array_map(function($item) use ($glue) {
 	  		if( is_array( $item ) ) {
 	  			return $this->r_implode( $item, $glue );
@@ -165,13 +165,27 @@ class Intervention_Wrapper {
 	  	}, $pieces);
 
 	  	return implode( $glue, $retVal );
-	} 
+	}
 
+    /**
+     * Recursively strips PHP callables out of an array, so we can serialize it nicely.
+     *
+     * @param   $args   the array from which to strip callables
+     * @return  the passed array, with all callables removed
+     */
+    private function strip_callables($args) {
 
+        // 1. recurse
+        $args = array_map(function($arg) {
+
+            return (is_array($arg)) ? $this->strip_callables($arg) : $arg;
+        }, $args);
+
+        // 2. strip all the things
+        return array_filter($args, function($arg) {
+
+            return !is_callable($arg);
+        });
+    }
 
 }
-
-
-
-	
-


### PR DESCRIPTION
As promised a few weeks ago =)

Intervention allows you to pass closures as parameters [to some functions](http://image.intervention.io/api/fit) (see the `callback` param). Doing so causes issues with cache filename generation, as PHP is unable to serialise/hash them properly.
This is a quick and dirty patch to strip any callables from the argument array before using it to generate the cache filename.

[edit] Apologies for the irritating whitespace changes: that’d be Atom trying to be useful, then… [/edit]